### PR TITLE
Simplify nodejs github action workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,22 +1,13 @@
 name: Node CI
 
-on: [push]
+on: push
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
     - name: Yarn CLI
       uses: CultureHQ/actions-yarn@v1.0.1
     - name: install and test


### PR DESCRIPTION
Remove node matrix and use the default node version provided by GitHub actions